### PR TITLE
Set UseParallelGC (Java 11) by default

### DIFF
--- a/bin/tlc
+++ b/bin/tlc
@@ -1,2 +1,9 @@
 #!/bin/sh
-exec java -cp PREFIX/lib/tla2tools.jar tlc2.TLC "$@"
+
+DEFAULT_JAVA_OPTS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseParallelGC"
+
+if [ -z "$JAVA_OPTS" ]; then
+  JAVA_OPTS="$DEFAULT_JAVA_OPTS"
+fi
+
+exec java $JAVA_OPTS -cp PREFIX/lib/tla2tools.jar tlc2.TLC "$@"


### PR DESCRIPTION
Based on [the TLC changelog entry](https://github.com/tlaplus/tlaplus/blob/14440ac4262807d3e0539b0a78fa77d3e881e3c6/general/docs/changelogs/ch1_5_8.md#command-line) describing recommended JVM options, and [Ron Pressler's comments](https://www.reddit.com/r/tlaplus/comments/ah86sm/introduction_to_tla_model_checking_in_the_command/) on TLC on the command line, this PR sets the `UseParallelGC` option by default for the `tlc` wrapper.

The JVM options can be overridden by setting the `JAVA_OPTS` environment variable when invoking `tlc`. I thought it wouldn't make much sense to set heap size options by default, so leaving that up to the user.