### PR TITLE
Git ignore tla2tools.jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tla2tools.jar


### PR DESCRIPTION
This is useful in a larger project: if I include tla-bin as a git submodule and run `tla-bin/download_or_update_tla.sh`, then the git submodule is considered "modified" unless tla2tools.jar is in .gitignore.