### PR TITLE
download: Download latest version from GitHub releases

### DIFF
--- a/download_or_update_tla.sh
+++ b/download_or_update_tla.sh
@@ -20,7 +20,7 @@ download_curl() {
 		if_modified="-z tla2tools.jar"
 	fi
 
-	curl -f -Ss -R -O $if_modified "$1"
+	curl -L -f -Ss -R -O $if_modified "$1"
 
 	if [ $? -ne 0 ]; then
 		echo "Couldn't download tla2tools.jar"
@@ -37,7 +37,7 @@ main() {
 		echo nightly
 		url=https://tla.msr-inria.inria.fr/tlatoolbox/ci/dist/tla2tools.jar
 	else
-		url=https://tla.msr-inria.inria.fr/tlatoolbox/dist/tla2tools.jar
+		url=https://github.com/tlaplus/tlaplus/releases/latest/download/tla2tools.jar
 	fi
 
 	echo "Downloading tla2tools.jar..."


### PR DESCRIPTION
Fixes #14.

Download the latest TLA+ version from GitHub releases.

The curl -L flag is now needed to follow redirects because the download
link uses GitHub's "/releases/latest" link, which is a redirect URL.

Ignore updating the nightly download URL link to avoid dealing with how
to figure out the latest nightly build available via GitHub releases.
The current link still works and installs the latest nightly build:

    $ ./download_or_update_tla.sh --nightly
    nightly
    Downloading tla2tools.jar...
    Updated tla2tools.jar
    New version: 2.18
    $ java -jar tla2tools.jar tlc2.TLC | grep Version
    TLC2 Version 2.18 of Day Month 20?? (rev: 95d980c)