### PR TITLE
Add tlc command line back to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ New file Euclid.cfg written.
 ### `tlc`, the TLA+ model checker
 
 ```
+$ tlc Euclid.tla
 TLC2 Version 2.16 of 31 December 2020 (rev: cdddf55)
 Running breadth-first search Model-Checking with fp 70 and seed -2731419115466680819 with 1 worker on 2 cores with 444MB heap and 64MB offheap memory [pid: 1039] (Linux 4.19.0-18-amd64 amd64, Debian 11.0.12 x86_64, MSBDiskFPSet, DiskStateQueue).
 Parsing file /home/pdm/tla-bin/tla/MC.tla


### PR DESCRIPTION
This line was removed in commit [9a90337](https://github.com/pmer/tla-bin/commit/9a9033721bbd78278d06b22cb19118249e72c1e5#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35)